### PR TITLE
Remake/task/17#13 インクリメントボタンを連打するとアプリが落ちるバグを修正

### DIFF
--- a/src/CoreLibrary/Counter.cs
+++ b/src/CoreLibrary/Counter.cs
@@ -106,11 +106,12 @@ namespace CoreLibrary
                     {
                         _count = await Repository.ReadAsync();
                         RaisePropertyChanged(nameof(Count));
+                        return;
                     }
                     catch (JsonReaderException) { }
                     catch (IOException exception)
                     {
-                        if (exception.HResult != -2147024864)
+                        if (!exception.Message.Contains("used by another process"))
                         {
                             throw;
                         }


### PR DESCRIPTION
連打ツールで一秒間に9回(111ミリ秒)の感覚でインクリメントボタンを1000回連打を３回繰り返してアプリが落ちない事を確認
`Debug.WriterLine`メソッドで`IOException`が発生しているか確認。
結果`IOException`は、7/1000回例外を吐いていた事が判明。
すべて2回目の`Read`メゾットの呼び出しでエラーの回避ができている事がわかった。